### PR TITLE
Native client can navigate to single backyard articles

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -6,6 +6,7 @@ import { createDrawerNavigator } from '@react-navigation/drawer';
 import { NavigationContainer } from '@react-navigation/native';
 import HomeStack from './components/HomeStack';
 import BackyardStack from './components/BackyardStack';
+import LoginView from './views/LoginView';
 
 window.store = store;
 
@@ -18,19 +19,25 @@ const App = () => {
     <Provider store={store}>
       <NavigationContainer>
         <Drawer.Navigator
+          initialRouteName='Home'
+          drawerStyle={{
+            backgroundColor: 'rgba(0,0,0,0.6)',
+            width: '52.5%',
+          }}
           drawerContentOptions={{
             activeBackgroundColor: '#CEC269',
             inactiveBackgroundColor: '#333',
             inactiveTintColor: 'white',
             activeTintColor: '#333',
-          }}
-          initialRouteName='Home'
-          drawerStyle={{
-            backgroundColor: 'rgba(0,0,0,0.6)',
-            width: '52.5%',
+            labelStyle: {
+              paddingLeft: 5,
+            },
           }}>
           <Drawer.Screen name='Home' component={HomeStack} />
           <Drawer.Screen name='Backyard Articles' component={BackyardStack} />
+          <Drawer.Screen name='Login'>
+            {(props) => <LoginView fromMenu={true} {...props} />}
+          </Drawer.Screen>
         </Drawer.Navigator>
       </NavigationContainer>
     </Provider>

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -8,7 +8,7 @@ const Article = ({ article, navigation }) => {
       testID='article'
       style={styles.row}
       onPress={() => {
-        navigation.navigate(authenticated ? 'single article' : 'logIn', {
+        navigation.navigate(authenticated ? 'single-article' : 'logIn', {
           article: article,
         });
       }}>

--- a/components/BackyardArticleCard.jsx
+++ b/components/BackyardArticleCard.jsx
@@ -1,14 +1,28 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 const BackyardArticleCard = ({ article, navigation }) => {
   return (
     <View style={styles.content}>
-      <Text testID='backyard-title' style={styles.title}>{article.title}</Text>
-      <View style={styles.cardContent}>
-        <Text testID='backyard-theme' style={styles.theme}>{article.theme}</Text>
-        <Text testID='backyard-written_by' style={styles.written_by}>{article.written_by}</Text>
-      </View>
+      <TouchableOpacity
+        onPress={() => {
+          navigation.navigate('backyard-article', {
+            article: article,
+          });
+        }}>
+        <Text testID='backyard-title' style={styles.title}>
+          {article.title}
+        </Text>
+        <View style={styles.cardContent}>
+          <Text testID='backyard-theme' style={styles.theme}>
+            {article.theme}
+          </Text>
+          <Text testID='backyard-written_by' style={styles.written_by}>
+            {article.written_by}
+          </Text>
+        </View>
+      </TouchableOpacity>
     </View>
   );
 };
@@ -19,7 +33,7 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     justifyContent: 'space-between',
-    borderRadius: '10px',
+    borderRadius: 10,
     shadowColor: '#000',
     shadowOffset: {
       width: 2,
@@ -41,16 +55,15 @@ const styles = StyleSheet.create({
   theme: {
     color: '#CEC269',
     fontSize: 10,
-  }, 
+  },
   written_by: {
     color: '#CEC269',
     fontSize: 10,
-    paddingLeft: 15
+    paddingLeft: 15,
   },
   cardContent: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignSelf: 'flex',
-    marginTop: 20
-  }
+    marginTop: 20,
+  },
 });

--- a/components/BackyardStack.jsx
+++ b/components/BackyardStack.jsx
@@ -38,7 +38,6 @@ const BackyardStack = () => {
           ),
         })}
       />
-
       <Stack.Screen
         name='backyard-article'
         component={SingleBackyardView}

--- a/components/BackyardStack.jsx
+++ b/components/BackyardStack.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AntDesign } from '@expo/vector-icons';
 import { createStackNavigator } from '@react-navigation/stack';
+import SingleBackyardView from '../views/SingleBackyardView';
 
 import BackyardView from '../views/BackyardView';
 
@@ -38,9 +39,9 @@ const BackyardStack = () => {
         })}
       />
 
-      {/* <Stack.Screen
+      <Stack.Screen
         name='backyard-article'
-        component={BackyardArticleView}
+        component={SingleBackyardView}
         options={({ navigation }) => ({
           title: 'Back',
           headerLeft: () => (
@@ -49,13 +50,13 @@ const BackyardStack = () => {
               style={{ color: '#CEC269', paddingLeft: 15 }}
               size={24}
               onPress={() => {
-                navigation.navigate('Home');
+                navigation.navigate('backyard-home');
                 store.dispatch({ type: 'RESET_ERROR' });
               }}
             />
           ),
         })}
-      /> */}
+      />
     </Stack.Navigator>
   );
 };

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -13,7 +13,7 @@ const Hero = ({ article, navigation }) => {
     <TouchableOpacity
       testID='hero-article'
       onPress={() => {
-        navigation.navigate('single article', {
+        navigation.navigate('single-article', {
           article: article,
         });
       }}>

--- a/components/HomeStack.jsx
+++ b/components/HomeStack.jsx
@@ -22,7 +22,7 @@ const HomeStack = () => {
         headerTintColor: '#CEC269',
       })}>
       <Stack.Screen
-        name='Home'
+        name='home'
         component={MainView}
         options={({ navigation }) => ({
           title: 'FAKE ? NEWS',
@@ -32,7 +32,7 @@ const HomeStack = () => {
           },
           headerLeft: () => (
             <AntDesign
-            testID='drawer-menu'
+              testID='drawer-menu'
               name='menu-fold'
               style={{ color: '#CEC269', paddingLeft: 15 }}
               size={24}
@@ -54,7 +54,7 @@ const HomeStack = () => {
               style={{ color: '#CEC269', paddingLeft: 15 }}
               size={24}
               onPress={() => {
-                navigation.navigate('Home');
+                navigation.navigate('home');
                 store.dispatch({ type: 'RESET_ERROR' });
               }}
             />
@@ -62,7 +62,7 @@ const HomeStack = () => {
         })}
       />
       <Stack.Screen
-        name='single article'
+        name='single-article'
         component={SingleArticleView}
         options={({ navigation }) => ({
           title: 'Back',
@@ -72,7 +72,7 @@ const HomeStack = () => {
               style={{ color: '#CEC269', paddingLeft: 15 }}
               size={24}
               onPress={() => {
-                navigation.navigate('Home');
+                navigation.navigate('home');
                 store.dispatch({ type: 'RESET_ERROR' });
               }}
             />
@@ -80,7 +80,7 @@ const HomeStack = () => {
         })}
       />
       <Stack.Screen
-        name='single category view'
+        name='single-category-view'
         component={SingleCategoryView}
         options={() => ({ title: category })}
       />

--- a/modules/BackyardArticles.js
+++ b/modules/BackyardArticles.js
@@ -18,6 +18,18 @@ const BackyardArticles = {
       });
     } catch (error) {}
   },
+
+  async show(id) {
+    try {
+      const response = await axios.get(`/backyards/${id}`);
+      store.dispatch({
+        type: 'SET_SINGLE_ARTICLE_VIEW',
+        payload: {
+          article: response.data.backyard_article,
+        },
+      });
+    } catch (error) {}
+  },
 };
 
 export default BackyardArticles;

--- a/views/LoginView.jsx
+++ b/views/LoginView.jsx
@@ -11,19 +11,27 @@ import {
 import store from '../state/store/configureStore';
 import { useSelector } from 'react-redux';
 import Authentication from '../modules/Authentication';
+import { AntDesign } from '@expo/vector-icons';
 
-const LoginView = ({ navigation, route }) => {
+const LoginView = ({ navigation, route, fromMenu }) => {
   const { errorMessage } = useSelector((state) => state);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const auth = new Authentication({ host: '' });
-  const article = route.params.article;
 
   const authenticate = async () => {
-    try {
-      await auth.signIn(email, password);
-      navigation.navigate('single article', { article: article });
-    } catch (error) {}
+    if (fromMenu) {
+      try {
+        await auth.signIn(email, password);
+        navigation.navigate('home');
+      } catch (error) {}
+    } else {
+      try {
+        const article = route.params.article;
+        await auth.signIn(email, password);
+        navigation.navigate('single-article', { article: article });
+      } catch (error) {}
+    }
   };
 
   return (
@@ -33,6 +41,20 @@ const LoginView = ({ navigation, route }) => {
         store.dispatch({ type: 'RESET_ERROR' });
       }}>
       <View style={styles.container}>
+        {fromMenu && (
+          <TouchableOpacity style={styles.backButton}>
+            <AntDesign
+              name='arrowleft'
+              style={{ color: '#CEC269', paddingLeft: 15 }}
+              size={24}
+              onPress={() => {
+                navigation.navigate('home');
+                store.dispatch({ type: 'RESET_ERROR' });
+              }}
+            />
+            <Text style={styles.backText}>Back</Text>
+          </TouchableOpacity>
+        )}
         <Text testID='login-header' style={styles.header}>
           Please log in to read this article
         </Text>
@@ -116,5 +138,18 @@ const styles = StyleSheet.create({
   text: {
     color: 'white',
     marginTop: 50,
+  },
+  backButton: {
+    flexDirection: 'row',
+    position: 'absolute',
+    top: 10,
+    left: 0,
+    alignItems: 'center',
+  },
+  backText: {
+    color: '#CEC269',
+    fontSize: 17,
+    fontWeight: 'bold',
+    marginLeft: 30,
   },
 });

--- a/views/SingleArticleView.jsx
+++ b/views/SingleArticleView.jsx
@@ -15,7 +15,7 @@ const SingleArticleView = (props) => {
   const articleId = props.route.params.article.id;
   const { article } = useSelector((state) => state);
   const showArticlesInCategory = () => {
-    props.navigation.navigate('single category view', {
+    props.navigation.navigate('single-category-view', {
       category: article.category,
     });
   };

--- a/views/SingleBackyardView.jsx
+++ b/views/SingleBackyardView.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
+import BackyardArticles from '../modules/BackyardArticles';
+
+const SingleBackyardView = ({ route }) => {
+  const { article } = useSelector((state) => state);
+  const { id } = route.params.article;
+
+  useEffect(() => {
+    BackyardArticles.show(id);
+  }, [id]);
+
+  return (
+    <ScrollView style={styles.container}>
+      <View >
+        <Text style={styles.header}>{article.title}</Text>
+        <Text style={styles.body}>{article.body}</Text>
+        <View style={styles.articleFooter}>
+          <Text style={styles.written_by}>By {article.written_by}</Text>
+          <Text style={styles.date}>{article.date}</Text>
+        </View>
+      </View>
+    </ScrollView>
+  );
+};
+
+export default SingleBackyardView;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#111518',
+    flex: 1,
+  },
+  header: {
+    padding: 15,
+    color: '#CEC269',
+    fontSize: 25,
+    backgroundColor: '#111518',
+  },
+  body: {
+    color: 'lightgray',
+    fontSize: 20,
+    padding: 15,
+  },
+  written_by: {
+    color: '#CEC269',
+    paddingTop: 2,
+    paddingLeft: 15,
+  },
+  date: {
+    color: 'gray',
+    paddingTop: 2,
+    paddingRight: 15,
+    textAlign: 'right',
+  },
+  articleFooter: {
+    flexDirection: 'row',
+    paddingTop: 5,
+    justifyContent: 'space-between',
+  },
+});


### PR DESCRIPTION
*PT-Story:**  https://www.pivotaltracker.com/story/show/178319454
### User Story 
``` 
As an API
In order to read the content of a backyard article
I would like to be taken to a screen with all info
``` 

## Changes proposed in this pull request: 
* Adds view for single backyard article
* Adds show action
* Adds login button in the drawer menu
* Adds conditionals to login functionality

## What I have learned working on this feature: 
* Navigation styling

## Screenshots (Client) 
![image](https://user-images.githubusercontent.com/75306727/120239627-f51d8900-c25e-11eb-9fe0-163a4d2ee658.png)
